### PR TITLE
Update PyO3 to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [".github/"]
 
 [dependencies]
 half = { version = "2.3", optional = true }
-pyo3 = { version = "0.20", optional = true }
+pyo3 = { version = "0.21", optional = true }
 
 [workspace]
 members = ["examples/from_numpy", "examples/with_pyo3", "examples/dlparkimg"]

--- a/examples/dlparkimg/Cargo.toml
+++ b/examples/dlparkimg/Cargo.toml
@@ -9,6 +9,6 @@ name = "dlparkimg"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.20.0"
+pyo3 = "0.21.0"
 dlpark = { path = "../../", features = ["pyo3"] }
 image = "0.25.0"

--- a/examples/dlparkimg/src/lib.rs
+++ b/examples/dlparkimg/src/lib.rs
@@ -53,7 +53,7 @@ fn write_image(filename: &str, tensor: ManagedTensor) {
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn dlparkimg(_py: Python, m: &PyModule) -> PyResult<()> {
+fn dlparkimg(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(read_image, m)?)?;
     m.add_function(wrap_pyfunction!(write_image, m)?)?;
     Ok(())

--- a/examples/with_pyo3/Cargo.toml
+++ b/examples/with_pyo3/Cargo.toml
@@ -10,6 +10,6 @@ name = "mylib"
 
 
 [dependencies]
-pyo3 = { version = "0.20.0", features = ["extension-module"] }
+pyo3 = { version = "0.21.0", features = ["extension-module"] }
 dlpark = { path = "../../", features = ["pyo3"] }
 ndarray = "0.15.6"

--- a/examples/with_pyo3/src/lib.rs
+++ b/examples/with_pyo3/src/lib.rs
@@ -9,18 +9,17 @@ pub fn add(left: usize, right: usize) -> usize {
 #[pyfunction]
 pub fn arange(n: usize) -> ManagerCtx<Vec<f32>> {
     let v: Vec<f32> = (0..n).map(|x| x as f32).collect();
-    let tensor = ManagerCtx::new(v);
-    tensor
+    ManagerCtx::new(v)
 }
 
 #[pyfunction]
-pub fn tensordict(py: Python<'_>) -> PyResult<&PyDict> {
-    let dic = PyDict::new(py);
+pub fn tensordict(py: Python<'_>) -> PyResult<Py<PyDict>> {
+    let dic = PyDict::new_bound(py);
     let v1: Vec<f32> = vec![1.0; 10];
     let v2: Vec<u8> = vec![2; 10];
     dic.set_item("v1", ManagerCtx::new(v1).into_py(py))?;
     dic.set_item("v2", ManagerCtx::new(v2).into_py(py))?;
-    Ok(dic)
+    Ok(dic.unbind())
 }
 
 #[pyfunction]
@@ -36,7 +35,7 @@ pub fn print_tensor(tensor: ManagedTensor) {
 }
 
 #[pymodule]
-fn mylib(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn mylib(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(add, m)?)?;
     m.add_function(wrap_pyfunction!(arange, m)?)?;
     m.add_function(wrap_pyfunction!(tensordict, m)?)?;

--- a/examples/with_pyo3/src/lib.rs
+++ b/examples/with_pyo3/src/lib.rs
@@ -13,13 +13,13 @@ pub fn arange(n: usize) -> ManagerCtx<Vec<f32>> {
 }
 
 #[pyfunction]
-pub fn tensordict(py: Python<'_>) -> PyResult<Py<PyDict>> {
+pub fn tensordict(py: Python<'_>) -> PyResult<Bound<'_, PyDict>> {
     let dic = PyDict::new_bound(py);
     let v1: Vec<f32> = vec![1.0; 10];
     let v2: Vec<u8> = vec![2; 10];
     dic.set_item("v1", ManagerCtx::new(v1).into_py(py))?;
     dic.set_item("v2", ManagerCtx::new(v2).into_py(py))?;
-    Ok(dic.unbind())
+    Ok(dic)
 }
 
 #[pyfunction]


### PR DESCRIPTION
Update PyO3 to [0.21](https://pyo3.rs/v0.21.0/changelog).

`dlpark` is really great. Hope to have a new release soon. Thanks.