### PR TITLE
Upgrade pyo3 to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [".github/"]
 
 [dependencies]
 half = { version = "2.3", optional = true }
-pyo3 = { version = "0.21", optional = true }
+pyo3 = { version = "0.23", optional = true }
 
 [workspace]
 members = ["examples/from_numpy", "examples/with_pyo3", "examples/dlparkimg"]

--- a/examples/dlparkimg/Cargo.toml
+++ b/examples/dlparkimg/Cargo.toml
@@ -9,6 +9,6 @@ name = "dlparkimg"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.21.0"
+pyo3 = "0.23"
 dlpark = { path = "../../", features = ["pyo3"] }
 image = "0.25.0"

--- a/examples/with_pyo3/Cargo.toml
+++ b/examples/with_pyo3/Cargo.toml
@@ -10,6 +10,6 @@ name = "mylib"
 
 
 [dependencies]
-pyo3 = { version = "0.21.0", features = ["extension-module"] }
+pyo3 = { version = "0.23", features = ["extension-module"] }
 dlpark = { path = "../../", features = ["pyo3"] }
 ndarray = "0.16.1"

--- a/src/python.rs
+++ b/src/python.rs
@@ -95,8 +95,8 @@ impl ManagedTensor {
 }
 
 impl<'source> FromPyObject<'source> for ManagedTensor {
-    fn extract(ob: &'source PyAny) -> PyResult<Self> {
-        Ok(ManagedTensor::from_py_ptr(ob.into_ptr()))
+    fn extract_bound(ob: &Bound<'source, PyAny>) -> PyResult<Self> {
+        Ok(ManagedTensor::from_py_ptr(ob.clone().into_ptr()))
     }
 }
 


### PR DESCRIPTION
Overview: Upgrade pyo3 version from 0.21 to 0.23.

Related and close https://github.com/SunDoge/dlpark/pull/17