### PR TITLE
Remove extra impl TryFrom<SafeManagedTensorVersioned>

### DIFF
--- a/src/versioned/safe_managed_tensor.rs
+++ b/src/versioned/safe_managed_tensor.rs
@@ -128,19 +128,6 @@ impl TensorView for SafeManagedTensorVersioned {
     }
 }
 
-/// Implements `Deref` to allow treating the tensor as a byte slice.
-impl std::ops::Deref for SafeManagedTensorVersioned {
-    type Target = [u8];
-
-    /// Dereferences the tensor to a byte slice.
-    ///
-    /// This allows the tensor to be used in contexts that expect a byte slice,
-    /// such as reading or writing the tensor's data.
-    fn deref(&self) -> &Self::Target {
-        self.as_slice_untyped()
-    }
-}
-
 impl AsRef<SafeManagedTensorVersioned> for SafeManagedTensorVersioned {
     fn as_ref(&self) -> &Self {
         self

--- a/src/versioned/safe_managed_tensor.rs
+++ b/src/versioned/safe_managed_tensor.rs
@@ -128,6 +128,19 @@ impl TensorView for SafeManagedTensorVersioned {
     }
 }
 
+/// Implements `Deref` to allow treating the tensor as a byte slice.
+impl std::ops::Deref for SafeManagedTensorVersioned {
+    type Target = [u8];
+
+    /// Dereferences the tensor to a byte slice.
+    ///
+    /// This allows the tensor to be used in contexts that expect a byte slice,
+    /// such as reading or writing the tensor's data.
+    fn deref(&self) -> &Self::Target {
+        self.as_slice_untyped()
+    }
+}
+
 impl AsRef<SafeManagedTensorVersioned> for SafeManagedTensorVersioned {
     fn as_ref(&self) -> &Self {
         self


### PR DESCRIPTION
Trying to fix compile error at https://github.com/SunDoge/dlpark/pull/25

```rust
error[E0277]: the trait bound `SafeManagedTensorVersioned: Deref` is not satisfied
   --> src/convertor/image.rs:90:56
    |
90  |         let img = ImageBuffer::from_raw(width, height, value).expect("container is not big enough");
    |                   ---------------------                ^^^^^ the trait `Deref` is not implemented for `SafeManagedTensorVersioned`
    |                   |
    |                   required by a bound introduced by this call
    |
note: required by a bound in `ImageBuffer::<P, Container>::from_raw`
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/image-0.25.6/src/buffer.rs:667:16
    |
667 |     Container: Deref<Target = [P::Subpixel]>,
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ImageBuffer::<P, Container>::from_raw`
...
674 |     pub fn from_raw(width: u32, height: u32, buf: Container) -> Option<ImageBuffer<P, Container>> {
    |            -------- required by a bound in this associated function
help: consider borrowing here
    |
90  |         let img = ImageBuffer::from_raw(width, height, &value).expect("container is not big enough");
    |                                                        +
90  |         let img = ImageBuffer::from_raw(width, height, &mut value).expect("container is not big enough");
    |                                                        ++++

For more information about this error, try `rustc --explain E0277`.
error: could not compile `dlpark` (lib) due to 1 previous error
```

Doing so by just removing the entire `impl<P> TryFrom<SafeManagedTensorVersioned> for ImageBuffer<P, SafeManagedTensorVersioned>` block, possibly forgotten during 465e0ad1ced53c6ef1e3710400f16c14242a10fe when `impl<P> TryFrom<SafeManagedTensor> for ImageBuffer<P, SafeManagedTensor>` was removed.