### PR TITLE
Replace pyo3 0.26.0 deprecated functions

### DIFF
--- a/src/convertor/python.rs
+++ b/src/convertor/python.rs
@@ -119,8 +119,8 @@ mod tests {
 
     #[test]
     fn test_dlpack() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        Python::initialize();
+        Python::attach(|py| {
             let mt =
                 SafeManagedTensor::new(vec![1i32, 2, 3]).expect("fail to make safe managed tensor");
             let ptr = mt.data_ptr();
@@ -132,8 +132,8 @@ mod tests {
 
     #[test]
     fn test_dlpack_versioned() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        Python::initialize();
+        Python::attach(|py| {
             let mt = SafeManagedTensorVersioned::new(vec![1i32, 2, 3])
                 .expect("fail to make safe managed tensor");
             let ptr = mt.data_ptr();


### PR DESCRIPTION
Xref https://pyo3.rs/v0.26.0/migration.html#from-025-to-026. Changes include:
- `pyo3::prepare_freethreaded_python` -> `Python::initialize`
- `pyo3::Python::<'_>::with_gil` -> `Python::attach`

Silences these warnings at https://github.com/SunDoge/dlpark/actions/runs/17364393631/job/49288936810#step:4:128:

```rust
warning: use of deprecated function `pyo3::prepare_freethreaded_python`: use `Python::initialize` instead
   --> src/convertor/python.rs:122:15
    |
122 |         pyo3::prepare_freethreaded_python();
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated function `pyo3::prepare_freethreaded_python`: use `Python::initialize` instead
   --> src/convertor/python.rs:135:15
    |
135 |         pyo3::prepare_freethreaded_python();
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: use of deprecated associated function `pyo3::Python::<'_>::with_gil`: use `Python::attach` instead
   --> src/convertor/python.rs:123:17
    |
123 |         Python::with_gil(|py| {
    |                 ^^^^^^^^

warning: use of deprecated associated function `pyo3::Python::<'_>::with_gil`: use `Python::attach` instead
   --> src/convertor/python.rs:136:17
    |
136 |         Python::with_gil(|py| {
    |                 ^^^^^^^^

warning: `dlpark` (lib test) generated 4 warnings
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.63s
     Running `/home/runner/work/dlpark/dlpark/target/debug/deps/dlpark-461aa6f8d61f551c`
```