### PR TITLE
Create impl TensorLike and TryFrom for CudaView

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: cargo build --verbose --features "pyo3 half ndarray image"
+        run: cargo build --verbose --features "pyo3 half ndarray image cuda"
       - name: Run tests
         run: cargo test --verbose --features "pyo3 half ndarray image"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ ndarray = "0.16"
 pyo3 = "0.27"
 image = "0.25"
 dlpark = { path = ".", default-features = false } # Add dlpark as a workspace dependency
-cudarc = "0.17.0"
+cudarc = "0.17.7"
 
 [features]
 default = []
@@ -47,7 +47,7 @@ ndarray = ["dep:ndarray"]
 image = ["dep:image"]
 
 
-cuda = ["dep:cudarc"]
+cuda = ["cudarc/fallback-latest", "cudarc/cuda-version-from-build-system"]
 
 # Not supported yet
 # candle-cpu = ["dep:candle-core"]

--- a/src/convertor/cuda.rs
+++ b/src/convertor/cuda.rs
@@ -52,8 +52,7 @@ where
     }
 
     fn device(&self) -> crate::Result<crate::ffi::Device> {
-        // Ok(crate::ffi::Device::cuda(self.ordinal()))
-        Ok(crate::ffi::Device::cuda(0))
+        Ok(crate::ffi::Device::cuda(self.stream().context().ordinal()))
     }
 
     fn data_type(&self) -> crate::Result<crate::ffi::DataType> {

--- a/src/convertor/cuda.rs
+++ b/src/convertor/cuda.rs
@@ -1,11 +1,10 @@
-use crate::prelude::*;
-use crate::{
-    error::UnsupportedDeviceSnafu,
-    ffi::DeviceType,
-    traits::{InferDataType, RowMajorCompactLayout, TensorLike},
-};
-use cudarc::driver::{CudaContext, CudaSlice, CudaView, DevicePtr};
+use cudarc::driver::{CudaContext, CudaSlice, CudaView, DevicePtr, DeviceSlice};
 use snafu::ensure;
+
+use crate::error::UnsupportedDeviceSnafu;
+use crate::ffi::DeviceType;
+use crate::prelude::*;
+use crate::traits::{InferDataType, RowMajorCompactLayout, TensorLike};
 
 impl<T> TensorLike<RowMajorCompactLayout> for CudaSlice<T>
 where
@@ -25,6 +24,36 @@ where
 
     fn device(&self) -> crate::Result<crate::ffi::Device> {
         Ok(crate::ffi::Device::cuda(self.ordinal()))
+    }
+
+    fn data_type(&self) -> crate::Result<crate::ffi::DataType> {
+        Ok(T::data_type())
+    }
+
+    fn byte_offset(&self) -> u64 {
+        0
+    }
+}
+
+impl<T> TensorLike<RowMajorCompactLayout> for CudaView<'_, T>
+where
+    T: InferDataType,
+{
+    type Error = crate::Error;
+
+    fn data_ptr(&self) -> *mut std::ffi::c_void {
+        let stream = self.stream();
+        let (ptr, _) = self.device_ptr(stream);
+        ptr as *mut T as *mut _
+    }
+
+    fn memory_layout(&self) -> RowMajorCompactLayout {
+        RowMajorCompactLayout::new(vec![self.len() as i64])
+    }
+
+    fn device(&self) -> crate::Result<crate::ffi::Device> {
+        // Ok(crate::ffi::Device::cuda(self.ordinal()))
+        Ok(crate::ffi::Device::cuda(0))
     }
 
     fn data_type(&self) -> crate::Result<crate::ffi::DataType> {
@@ -60,6 +89,30 @@ impl<'a, T> TryFrom<&'a SafeManagedTensor> for CudaView<'a, T> {
     }
 }
 
+impl<'a, T> TryFrom<&'a SafeManagedTensorVersioned> for CudaView<'a, T> {
+    type Error = crate::Error;
+
+    fn try_from(value: &'a SafeManagedTensorVersioned) -> Result<Self, Self::Error> {
+        let device = value.device();
+        ensure!(
+            device.device_type == DeviceType::Cuda,
+            UnsupportedDeviceSnafu {
+                device: device.device_type
+            }
+        );
+
+        let ctx = CudaContext::new(device.device_id as usize).unwrap();
+        let stream = ctx.default_stream();
+        unsafe {
+            let s = stream.upgrade_device_ptr(value.data_ptr() as u64, value.num_elements());
+            let temp_view: CudaView<'_, T> = s.slice(..);
+            let view = std::mem::transmute::<CudaView<'_, T>, CudaView<'_, T>>(temp_view);
+            s.leak();
+            Ok(view)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -70,6 +123,19 @@ mod tests {
         let stream = ctx.default_stream();
         let slice = stream.alloc_zeros::<f32>(10).unwrap();
         let mt = SafeManagedTensor::new(slice).unwrap();
+        assert_eq!(mt.num_elements(), 10);
+        let view = CudaView::<f32>::try_from(&mt).unwrap();
+        assert_eq!(view.len(), 10);
+    }
+
+    #[test]
+    fn test_cuda_view() {
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let slice = stream.alloc_zeros::<f32>(10).unwrap();
+        let view = slice.slice(..);
+
+        let mt = SafeManagedTensorVersioned::new(view).unwrap();
         assert_eq!(mt.num_elements(), 10);
         let view = CudaView::<f32>::try_from(&mt).unwrap();
         assert_eq!(view.len(), 10);


### PR DESCRIPTION
Allow roundtrip conversion from `cudarc::driver::CudaView` to `SafeManagedTensorVersioned`.

Also bumped `cudarc` from 0.17.0 to 0.17.7 and enabled the 'fallback-latest' feature flag (see https://github.com/coreylowman/cudarc/pull/482) which means we can compile using our local CUDA version, while allowing `cargo build` on CI (which fallbacks to using cuda-13000 currently).