### PR TITLE
feat!: add safe  `array_view_from_dlpack_mut` and `cpu_data_slice_mut`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -78,8 +78,27 @@ impl<C, L> Builder<C, L> {
         self
     }
 
+    /// Sets DLPack flags, erroring if this would newly assert
+    /// [`DlpackFlags::IS_COPIED`] (turn it on when it wasn't already set on
+    /// this builder). See [`Self::flags_unchecked`].
     #[inline]
-    pub fn flags(mut self, flags: DlpackFlags) -> Self {
+    pub fn flags(mut self, flags: DlpackFlags) -> Result<Self, crate::tensor::Error> {
+        if flags.newly_asserts_is_copied(self.fields.flags) {
+            return Err(crate::tensor::Error::CannotAssertIsCopied);
+        }
+        self.fields.flags = flags;
+        Ok(self)
+    }
+
+    /// Sets DLPack flags verbatim, including [`DlpackFlags::IS_COPIED`].
+    ///
+    /// # Safety
+    ///
+    /// If `flags` includes `IS_COPIED`, the caller must ensure that no other
+    /// reference to the tensor's data exists — see
+    /// [`ManagedTensorBase::set_flags_unchecked`].
+    #[inline]
+    pub unsafe fn flags_unchecked(mut self, flags: DlpackFlags) -> Self {
         self.fields.flags = flags;
         self
     }
@@ -351,7 +370,7 @@ where
             tensor.dtype = fields.dtype;
             tensor.byte_offset = fields.byte_offset;
         }
-        managed_ref.set_flags(fields.flags);
+        managed_ref.set_flags_unchecked(fields.flags);
     }
     managed
 }
@@ -548,11 +567,42 @@ mod tests {
                 .data(data)
                 .byte_offset(4)
                 .flags(DlpackFlags::READ_ONLY)
+                .unwrap()
                 .build();
 
         assert_eq!(tensor.tensor().data, data);
         assert_eq!(tensor.tensor().byte_offset, 4);
         assert_eq!(tensor.flags(), DlpackFlags::READ_ONLY);
+    }
+
+    #[test]
+    fn flags_rejects_newly_asserting_is_copied() {
+        let (ctx, _) = context();
+
+        let error = match Builder::new(ctx, metadata::CopiedArray::new(&[3], &[1]))
+            .flags(DlpackFlags::READ_ONLY | DlpackFlags::IS_COPIED)
+        {
+            Ok(_) => panic!("newly asserting IS_COPIED through the safe setter should fail"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(error, crate::tensor::Error::CannotAssertIsCopied));
+    }
+
+    #[test]
+    fn flags_unchecked_keeps_is_copied() {
+        let (ctx, _) = context();
+
+        let tensor: ManagedBox<DLManagedTensorVersioned> = unsafe {
+            Builder::new(ctx, metadata::CopiedArray::new(&[3], &[1]))
+                .flags_unchecked(DlpackFlags::READ_ONLY | DlpackFlags::IS_COPIED)
+        }
+        .build();
+
+        assert_eq!(
+            tensor.flags(),
+            DlpackFlags::READ_ONLY | DlpackFlags::IS_COPIED
+        );
     }
 
     #[test]

--- a/src/dlpack.rs
+++ b/src/dlpack.rs
@@ -78,7 +78,7 @@ where
         self.tensor().cpu_data_slice()
     }
 
-    /// Returns the CPU tensor data as a mutable typed slice.
+    /// Returns the CPU tensor data as a mutable typed slice, without proving exclusivity.
     ///
     /// This rejects versioned tensors carrying [`DlpackFlags::READ_ONLY`].
     /// Legacy tensors have no flags and are treated as writable.
@@ -88,7 +88,9 @@ where
     /// The caller must ensure that no other references access the underlying
     /// data for the lifetime of the returned slice. Exclusive access to this
     /// `ManagedBox` alone does not prove that the producer has no aliases.
-    pub unsafe fn cpu_data_slice_mut<T: DlpackElement>(
+    /// Prefer [`Self::cpu_data_slice_mut`], which additionally requires
+    /// [`DlpackFlags::IS_COPIED`] and needs no `unsafe` block.
+    pub unsafe fn cpu_data_slice_mut_unchecked<T: DlpackElement>(
         &mut self,
     ) -> Result<&mut [T], tensor::Error> {
         if self.flags().contains(DlpackFlags::READ_ONLY) {
@@ -102,6 +104,22 @@ where
         let len = tensor.num_elements()?;
         let data = tensor.cpu_data_ptr::<T>()?.cast_mut();
         Ok(unsafe { std::slice::from_raw_parts_mut(data, len) })
+    }
+
+    /// Returns the CPU tensor data as a mutable typed slice.
+    ///
+    /// This rejects tensors carrying [`DlpackFlags::READ_ONLY`], and requires
+    /// [`DlpackFlags::IS_COPIED`] to be set: per the DLPack spec, a tensor
+    /// copied specifically for this export has no other live aliases, which
+    /// is what makes this safe to call without an `unsafe` block. Legacy
+    /// tensors have no flags field and so can never satisfy `IS_COPIED`; use
+    /// [`Self::cpu_data_slice_mut_unchecked`] for those.
+    pub fn cpu_data_slice_mut<T: DlpackElement>(&mut self) -> Result<&mut [T], tensor::Error> {
+        if !self.flags().contains(DlpackFlags::IS_COPIED) {
+            return Err(tensor::Error::NotCopied);
+        }
+
+        unsafe { self.cpu_data_slice_mut_unchecked() }
     }
 }
 
@@ -125,7 +143,25 @@ impl ManagedBox<DLManagedTensorVersioned> {
         unsafe { self.0.as_ref() }.flags
     }
 
-    pub fn flags_mut(&mut self) -> &mut DlpackFlags {
+    /// Sets DLPack flags, erroring if this would newly assert
+    /// [`DlpackFlags::IS_COPIED`] (turn it on when it wasn't already set).
+    /// See [`Self::flags_mut`] to assert it.
+    pub fn set_flags(&mut self, flags: DlpackFlags) -> Result<(), tensor::Error> {
+        if flags.newly_asserts_is_copied(self.flags()) {
+            return Err(tensor::Error::CannotAssertIsCopied);
+        }
+        *unsafe { self.flags_mut() } = flags;
+        Ok(())
+    }
+
+    /// Returns a mutable reference to the DLPack bitmask flags.
+    ///
+    /// # Safety
+    ///
+    /// Writing [`DlpackFlags::IS_COPIED`] through this reference asserts
+    /// that no other reference to the tensor's data exists — see
+    /// [`crate::managed_tensor::ManagedTensorBase::set_flags_unchecked`].
+    pub unsafe fn flags_mut(&mut self) -> &mut DlpackFlags {
         &mut unsafe { self.0.as_mut() }.flags
     }
 
@@ -155,58 +191,55 @@ mod tests {
     use crate::{builder::Builder, ffi::DLManagedTensor, metadata};
     use std::ffi::c_void;
 
+    /// Builds a `[1, 2, 3]` i32 tensor of type `M` with the given flags.
+    ///
+    /// `flags` is a no-op for `M = DLManagedTensor`, which has no flags field.
+    fn dlpack_with_flags<M: ManagedTensorBase>(flags: DlpackFlags) -> ManagedBox<M> {
+        let data = Box::new(vec![1i32, 2, 3]);
+        let data_ptr = data.as_ptr() as *mut c_void;
+        let builder = Builder::new(data, metadata::CopiedArray::new([3i64], [1i64]))
+            .data(data_ptr)
+            .dtype(crate::ffi::DLDataType::of::<i32>());
+        // Safety: the fixture data above has no other live references.
+        unsafe { builder.flags_unchecked(flags) }.build::<M>()
+    }
+
     #[test]
     fn versioned_flags_roundtrip_through_builder() {
-        let data = Box::new(vec![1i32, 2, 3]);
-        let dlpack = Builder::new(data, metadata::CopiedArray::new([3i64], [1i64]))
-            .flags(DlpackFlags::READ_ONLY)
-            .build::<DLManagedTensorVersioned>();
+        let dlpack = dlpack_with_flags::<DLManagedTensorVersioned>(DlpackFlags::READ_ONLY);
 
         assert_eq!(dlpack.flags(), DlpackFlags::READ_ONLY);
     }
 
     #[test]
     fn versioned_flags_default_to_empty() {
-        let data = Box::new(vec![1i32, 2, 3]);
-        let dlpack = Builder::new(data, metadata::CopiedArray::new([3i64], [1i64]))
-            .build::<DLManagedTensorVersioned>();
+        let dlpack = dlpack_with_flags::<DLManagedTensorVersioned>(DlpackFlags::empty());
 
         assert_eq!(dlpack.flags(), DlpackFlags::empty());
     }
 
     #[test]
-    fn mutable_cpu_slice_updates_writable_tensor() {
-        let data = Box::new(vec![1i32, 2, 3]);
-        let data_ptr = data.as_ptr() as *mut c_void;
-        let mut dlpack = Builder::new(data, metadata::CopiedArray::new([3i64], [1i64]))
-            .data(data_ptr)
-            .dtype(crate::ffi::DLDataType::of::<i32>())
-            .build::<DLManagedTensor>();
+    fn mutable_cpu_slice_unchecked_updates_writable_tensor() {
+        let mut dlpack = dlpack_with_flags::<DLManagedTensor>(DlpackFlags::empty());
 
         unsafe {
-            dlpack.cpu_data_slice_mut::<i32>().unwrap()[1] = 7;
+            dlpack.cpu_data_slice_mut_unchecked::<i32>().unwrap()[1] = 7;
         }
 
         assert_eq!(dlpack.cpu_data_slice::<i32>().unwrap(), &[1, 7, 3]);
     }
 
     #[test]
-    fn mutable_cpu_slice_rejects_read_only_tensor() {
-        let data = Box::new(vec![1i32, 2, 3]);
-        let data_ptr = data.as_ptr() as *mut c_void;
-        let mut dlpack = Builder::new(data, metadata::CopiedArray::new([3i64], [1i64]))
-            .data(data_ptr)
-            .dtype(crate::ffi::DLDataType::of::<i32>())
-            .flags(DlpackFlags::READ_ONLY)
-            .build::<DLManagedTensorVersioned>();
+    fn mutable_cpu_slice_unchecked_rejects_read_only_tensor() {
+        let mut dlpack = dlpack_with_flags::<DLManagedTensorVersioned>(DlpackFlags::READ_ONLY);
 
-        let error = unsafe { dlpack.cpu_data_slice_mut::<i32>() }.unwrap_err();
+        let error = unsafe { dlpack.cpu_data_slice_mut_unchecked::<i32>() }.unwrap_err();
 
         assert!(matches!(error, tensor::Error::ReadOnly));
     }
 
     #[test]
-    fn mutable_cpu_slice_rejects_non_compact_strides() {
+    fn mutable_cpu_slice_unchecked_rejects_non_compact_strides() {
         let data = Box::new(vec![1i32, 2, 3, 4]);
         let data_ptr = data.as_ptr() as *mut c_void;
         let mut dlpack = Builder::new(data, metadata::CopiedArray::new([2, 2], [1, 2]))
@@ -214,8 +247,46 @@ mod tests {
             .dtype(crate::ffi::DLDataType::of::<i32>())
             .build::<DLManagedTensor>();
 
-        let error = unsafe { dlpack.cpu_data_slice_mut::<i32>() }.unwrap_err();
+        let error = unsafe { dlpack.cpu_data_slice_mut_unchecked::<i32>() }.unwrap_err();
 
         assert!(matches!(error, tensor::Error::NonCompactStrides));
+    }
+
+    #[test]
+    fn mutable_cpu_slice_updates_is_copied_tensor_without_unsafe() {
+        let mut dlpack = dlpack_with_flags::<DLManagedTensorVersioned>(DlpackFlags::IS_COPIED);
+
+        dlpack.cpu_data_slice_mut::<i32>().unwrap()[1] = 7;
+
+        assert_eq!(dlpack.cpu_data_slice::<i32>().unwrap(), &[1, 7, 3]);
+    }
+
+    #[test]
+    fn mutable_cpu_slice_rejects_tensor_without_is_copied() {
+        let mut dlpack = dlpack_with_flags::<DLManagedTensorVersioned>(DlpackFlags::empty());
+
+        let error = dlpack.cpu_data_slice_mut::<i32>().unwrap_err();
+
+        assert!(matches!(error, tensor::Error::NotCopied));
+    }
+
+    #[test]
+    fn mutable_cpu_slice_rejects_read_only_tensor_even_if_copied() {
+        let mut dlpack = dlpack_with_flags::<DLManagedTensorVersioned>(
+            DlpackFlags::READ_ONLY | DlpackFlags::IS_COPIED,
+        );
+
+        let error = dlpack.cpu_data_slice_mut::<i32>().unwrap_err();
+
+        assert!(matches!(error, tensor::Error::ReadOnly));
+    }
+
+    #[test]
+    fn mutable_cpu_slice_rejects_legacy_tensor_as_never_copied() {
+        let mut dlpack = dlpack_with_flags::<DLManagedTensor>(DlpackFlags::empty());
+
+        let error = dlpack.cpu_data_slice_mut::<i32>().unwrap_err();
+
+        assert!(matches!(error, tensor::Error::NotCopied));
     }
 }

--- a/src/interop/candle.rs
+++ b/src/interop/candle.rs
@@ -451,6 +451,7 @@ mod tests {
         let dlpack: ManagedBox<DLManagedTensorVersioned> = Builder::try_from(tensor)
             .unwrap()
             .flags(DlpackFlags::READ_ONLY)
+            .unwrap()
             .try_build()
             .unwrap();
 

--- a/src/interop/image.rs
+++ b/src/interop/image.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Builder, DlpackElement, ManagedBox, ManagedTensorBase,
+    Builder, DlpackElement, DlpackFlags, ManagedBox, ManagedTensorBase,
     ffi::{DLDevice, DLManagedTensor, DLManagedTensorVersioned},
     legacy, metadata,
     tensor::{compact_strides_array, is_compact_strides},
@@ -72,11 +72,13 @@ where
         let shape = [height as i64, width as i64, channels as i64];
         let strides = compact_strides_array(shape).expect("image shape must fit compact strides");
 
-        Builder::new(Box::new(img), metadata::CopiedArray::new(&shape, &strides))
+        let builder = Builder::new(Box::new(img), metadata::CopiedArray::new(&shape, &strides))
             .data(data_ptr)
             .dtype(P::Subpixel::DTYPE)
-            .device(DLDevice::CPU)
-            .build::<DLManagedTensor>()
+            .device(DLDevice::CPU);
+        // Safety: `img` was moved in above and its `Vec`-backed pixel buffer
+        // has no other live references.
+        unsafe { builder.flags_unchecked(DlpackFlags::IS_COPIED) }.build::<DLManagedTensor>()
     }
 }
 
@@ -93,11 +95,13 @@ where
         let shape = [height as i64, width as i64, channels as i64];
         let strides = compact_strides_array(shape).expect("image shape must fit compact strides");
 
-        Builder::new(Box::new(img), metadata::CopiedArray::new(&shape, &strides))
+        let builder = Builder::new(Box::new(img), metadata::CopiedArray::new(&shape, &strides))
             .data(data_ptr)
             .dtype(P::Subpixel::DTYPE)
-            .device(DLDevice::CPU)
-            .build::<DLManagedTensorVersioned>()
+            .device(DLDevice::CPU);
+        // Safety: `img` was moved in above and its `Vec`-backed pixel buffer
+        // has no other live references.
+        unsafe { builder.flags_unchecked(DlpackFlags::IS_COPIED) }.build::<DLManagedTensorVersioned>()
     }
 }
 
@@ -271,6 +275,24 @@ mod tests {
         let dlpack = legacy::Dlpack::from(img);
 
         assert_eq!(dlpack.shape().unwrap(), &[4, 4, 3]);
+    }
+
+    #[test]
+    fn versioned_image_to_dlpack_sets_is_copied() {
+        let img = ImageBuffer::<Rgb<u8>, _>::from_vec(4, 4, vec![0u8; 48]).unwrap();
+        let dlpack = versioned::Dlpack::from(img);
+
+        assert_eq!(dlpack.flags(), DlpackFlags::IS_COPIED);
+    }
+
+    #[test]
+    fn versioned_image_to_dlpack_allows_safe_mutation() {
+        let img = ImageBuffer::<Rgb<u8>, _>::from_vec(4, 4, vec![0u8; 48]).unwrap();
+        let mut dlpack = versioned::Dlpack::from(img);
+
+        dlpack.cpu_data_slice_mut::<u8>().unwrap()[0] = 42;
+
+        assert_eq!(dlpack.cpu_data_slice::<u8>().unwrap()[0], 42);
     }
 
     #[test]

--- a/src/interop/ndarray.rs
+++ b/src/interop/ndarray.rs
@@ -1,7 +1,8 @@
 use crate::{
-    DlpackElement, dlpack::ManagedBox, ffi::DLDevice, managed_tensor::ManagedTensorBase, metadata,
+    DlpackElement, DlpackFlags, dlpack::ManagedBox, ffi::DLDevice,
+    managed_tensor::ManagedTensorBase, metadata,
 };
-use ndarray::{ArrayBase, ArrayViewD, Dimension, IxDyn, OwnedRepr, ShapeBuilder};
+use ndarray::{ArrayBase, ArrayViewD, ArrayViewMutD, Dimension, IxDyn, OwnedRepr, ShapeBuilder};
 use snafu::{ResultExt, Snafu, ensure};
 use std::os::raw::c_void;
 
@@ -51,6 +52,23 @@ where
     }
 }
 
+impl<'a, T, M> TryFrom<&'a mut ManagedBox<M>> for ArrayViewMutD<'a, T>
+where
+    T: DlpackElement,
+    M: ManagedTensorBase,
+{
+    type Error = Error;
+
+    fn try_from(dlpack: &'a mut ManagedBox<M>) -> Result<Self, Self::Error> {
+        array_view_from_dlpack_mut(dlpack)
+    }
+}
+
+/// Builds a DLPack tensor from an owned ndarray array.
+///
+/// `array` is moved in and its `Vec`-backed storage becomes exclusively owned
+/// by the returned tensor, so this sets [`DlpackFlags::IS_COPIED`] on
+/// versioned tensors (a no-op for legacy tensors, which have no flags field).
 pub fn dlpack_from_ndarray<T, D, M>(
     array: ArrayBase<OwnedRepr<T>, D>,
 ) -> Result<ManagedBox<M>, Error>
@@ -70,6 +88,7 @@ where
         Box::new(array),
         |array| (array.shape(), array.strides()),
     )?;
+    unsafe { managed.as_mut().set_flags_unchecked(DlpackFlags::IS_COPIED) };
     let tensor = unsafe { managed.as_mut() }.tensor_mut();
     tensor.data = data_ptr;
     tensor.dtype = T::DTYPE;
@@ -86,6 +105,69 @@ where
     M: ManagedTensorBase,
 {
     let tensor = dlpack.tensor();
+    let (shape, strides) = shape_and_strides(tensor)?;
+    let ptr = tensor.cpu_data_ptr::<T>()?;
+    let span_len = strided_span_len(&shape, &strides)?;
+    let data = unsafe { std::slice::from_raw_parts(ptr, span_len) };
+
+    ArrayViewD::from_shape(IxDyn(&shape).strides(IxDyn(&strides)), data).context(ShapeSnafu)
+}
+
+/// Returns a mutable ndarray view into a DLPack tensor's CPU data, without proving exclusivity.
+///
+/// This rejects versioned tensors carrying [`DlpackFlags::READ_ONLY`].
+/// Legacy tensors have no flags and are treated as writable.
+///
+/// # Safety
+///
+/// The caller must ensure that no other references access the underlying
+/// data for the lifetime of the returned view. Exclusive access to this
+/// `ManagedBox` alone does not prove that the producer has no aliases.
+/// Prefer [`array_view_from_dlpack_mut`], which additionally requires
+/// [`DlpackFlags::IS_COPIED`] and needs no `unsafe` block.
+pub unsafe fn array_view_from_dlpack_mut_unchecked<'a, T, M>(
+    dlpack: &'a mut ManagedBox<M>,
+) -> Result<ArrayViewMutD<'a, T>, Error>
+where
+    T: DlpackElement,
+    M: ManagedTensorBase,
+{
+    if dlpack.flags().contains(DlpackFlags::READ_ONLY) {
+        return Err(crate::tensor::Error::ReadOnly.into());
+    }
+
+    let tensor = dlpack.tensor();
+    let (shape, strides) = shape_and_strides(tensor)?;
+    let ptr = tensor.cpu_data_ptr::<T>()?.cast_mut();
+    let span_len = strided_span_len(&shape, &strides)?;
+    let data = unsafe { std::slice::from_raw_parts_mut(ptr, span_len) };
+
+    ArrayViewMutD::from_shape(IxDyn(&shape).strides(IxDyn(&strides)), data).context(ShapeSnafu)
+}
+
+/// Returns a mutable ndarray view into a DLPack tensor's CPU data.
+///
+/// This rejects tensors carrying [`DlpackFlags::READ_ONLY`], and requires
+/// [`DlpackFlags::IS_COPIED`] to be set: per the DLPack spec, a tensor
+/// copied specifically for this export has no other live aliases, which is
+/// what makes this safe to call without an `unsafe` block. Legacy tensors
+/// have no flags field and so can never satisfy `IS_COPIED`; use
+/// [`array_view_from_dlpack_mut_unchecked`] for those.
+pub fn array_view_from_dlpack_mut<'a, T, M>(
+    dlpack: &'a mut ManagedBox<M>,
+) -> Result<ArrayViewMutD<'a, T>, Error>
+where
+    T: DlpackElement,
+    M: ManagedTensorBase,
+{
+    if !dlpack.flags().contains(DlpackFlags::IS_COPIED) {
+        return Err(crate::tensor::Error::NotCopied.into());
+    }
+
+    unsafe { array_view_from_dlpack_mut_unchecked(dlpack) }
+}
+
+fn shape_and_strides(tensor: &crate::ffi::DLTensor) -> Result<(Vec<usize>, Vec<usize>), Error> {
     let shape = tensor
         .shape()?
         .iter()
@@ -115,11 +197,7 @@ where
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let ptr = tensor.cpu_data_ptr::<T>()?;
-    let span_len = strided_span_len(&shape, &strides)?;
-    let data = unsafe { std::slice::from_raw_parts(ptr, span_len) };
-
-    ArrayViewD::from_shape(IxDyn(&shape).strides(IxDyn(&strides)), data).context(ShapeSnafu)
+    Ok((shape, strides))
 }
 
 fn strided_span_len(shape: &[usize], strides: &[usize]) -> Result<usize, Error> {
@@ -145,10 +223,29 @@ mod tests {
     use crate::{legacy, versioned};
     use ndarray::{Array, arr2};
 
+    /// A `[[1, 2, 3], [4, 5, 6]]` legacy tensor. Legacy tensors have no flags
+    /// field, so this is always writable via the `_unchecked` accessors and
+    /// never satisfies `IS_COPIED`.
+    fn legacy_2x3_dlpack() -> legacy::Dlpack {
+        legacy::Dlpack::try_from(arr2(&[[1i32, 2, 3], [4, 5, 6]])).unwrap()
+    }
+
+    /// The transpose of [`legacy_2x3_dlpack`]'s array, i.e. non-compact strides.
+    fn legacy_3x2_transposed_dlpack() -> legacy::Dlpack {
+        let array = arr2(&[[1i32, 2, 3], [4, 5, 6]]);
+        legacy::Dlpack::try_from(array.reversed_axes().to_owned()).unwrap()
+    }
+
+    /// A `[[1, 2, 3], [4, 5, 6]]` versioned tensor carrying the given flags.
+    fn versioned_2x3_dlpack(flags: DlpackFlags) -> versioned::Dlpack {
+        let mut dlpack = versioned::Dlpack::try_from(arr2(&[[1i32, 2, 3], [4, 5, 6]])).unwrap();
+        dlpack.set_flags(flags).unwrap();
+        dlpack
+    }
+
     #[test]
     fn owned_ndarray_to_legacy_dlpack_keeps_layout_and_data() {
-        let array = arr2(&[[1i32, 2, 3], [4, 5, 6]]);
-        let dlpack = legacy::Dlpack::try_from(array).unwrap();
+        let dlpack = legacy_2x3_dlpack();
 
         assert_eq!(dlpack.shape().unwrap(), &[2, 3]);
         assert_eq!(dlpack.strides().unwrap().unwrap(), &[3, 1]);
@@ -166,6 +263,27 @@ mod tests {
     }
 
     #[test]
+    fn owned_ndarray_to_versioned_dlpack_sets_is_copied() {
+        let array = Array::from_shape_vec((2, 2), vec![1f32, 2., 3., 4.]).unwrap();
+        let dlpack = versioned::Dlpack::try_from(array).unwrap();
+
+        assert_eq!(dlpack.flags(), DlpackFlags::IS_COPIED);
+    }
+
+    #[test]
+    fn owned_ndarray_to_versioned_dlpack_allows_safe_mutation() {
+        let array = Array::from_shape_vec((2, 2), vec![1f32, 2., 3., 4.]).unwrap();
+        let mut dlpack = versioned::Dlpack::try_from(array).unwrap();
+
+        dlpack.cpu_data_slice_mut::<f32>().unwrap()[1] = 42.;
+
+        assert_eq!(
+            dlpack.cpu_data_slice::<f32>().unwrap(),
+            &[1., 42., 3., 4.]
+        );
+    }
+
+    #[test]
     fn owned_arrayd_to_dlpack_keeps_dynamic_shape() {
         let array = arr2(&[[1i32, 2], [3, 4]]).into_dyn();
         let dlpack = legacy::Dlpack::try_from(array).unwrap();
@@ -177,8 +295,7 @@ mod tests {
 
     #[test]
     fn borrowed_dlpack_to_ndarray_view_is_zero_copy() {
-        let array = arr2(&[[1i32, 2, 3], [4, 5, 6]]);
-        let dlpack = legacy::Dlpack::try_from(array).unwrap();
+        let dlpack = legacy_2x3_dlpack();
         let view = ArrayViewD::<i32>::try_from(&dlpack).unwrap();
 
         assert_eq!(view.shape(), &[2, 3]);
@@ -188,14 +305,111 @@ mod tests {
 
     #[test]
     fn borrowed_dlpack_to_ndarray_view_preserves_strides() {
-        let array = arr2(&[[1i32, 2, 3], [4, 5, 6]]);
-        let transposed = array.reversed_axes().to_owned();
-        let dlpack = legacy::Dlpack::try_from(transposed).unwrap();
+        let dlpack = legacy_3x2_transposed_dlpack();
         let view = array_view_from_dlpack::<i32, _>(&dlpack).unwrap();
 
         assert_eq!(view.shape(), &[3, 2]);
         assert_eq!(view.strides(), &[1, 3]);
         assert_eq!(view[[2, 1]], 6);
+    }
+
+    #[test]
+    fn borrowed_dlpack_to_mut_ndarray_view_unchecked_writes_through() {
+        let mut dlpack = legacy_2x3_dlpack();
+        let mut view =
+            unsafe { array_view_from_dlpack_mut_unchecked::<i32, _>(&mut dlpack).unwrap() };
+
+        assert_eq!(view.shape(), &[2, 3]);
+        assert_eq!(view.strides(), &[3, 1]);
+        view[[1, 2]] = 42;
+
+        assert_eq!(
+            dlpack.cpu_data_slice::<i32>().unwrap(),
+            &[1, 2, 3, 4, 5, 42]
+        );
+    }
+
+    #[test]
+    fn borrowed_dlpack_to_mut_ndarray_view_unchecked_preserves_strides() {
+        let mut dlpack = legacy_3x2_transposed_dlpack();
+        let mut view =
+            unsafe { array_view_from_dlpack_mut_unchecked::<i32, _>(&mut dlpack).unwrap() };
+
+        assert_eq!(view.shape(), &[3, 2]);
+        assert_eq!(view.strides(), &[1, 3]);
+        view[[2, 1]] = 42;
+
+        let view = array_view_from_dlpack::<i32, _>(&dlpack).unwrap();
+        assert_eq!(view[[2, 1]], 42);
+    }
+
+    #[test]
+    fn mut_ndarray_view_unchecked_rejects_read_only_tensor() {
+        let mut dlpack = versioned_2x3_dlpack(DlpackFlags::READ_ONLY);
+
+        let error =
+            unsafe { array_view_from_dlpack_mut_unchecked::<i32, _>(&mut dlpack) }.unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::Tensor {
+                source: crate::tensor::Error::ReadOnly
+            }
+        ));
+    }
+
+    #[test]
+    fn mut_ndarray_view_updates_is_copied_tensor_without_unsafe() {
+        let mut dlpack = versioned_2x3_dlpack(DlpackFlags::IS_COPIED);
+
+        let mut view = array_view_from_dlpack_mut::<i32, _>(&mut dlpack).unwrap();
+        view[[1, 2]] = 42;
+
+        assert_eq!(
+            dlpack.cpu_data_slice::<i32>().unwrap(),
+            &[1, 2, 3, 4, 5, 42]
+        );
+    }
+
+    #[test]
+    fn mut_ndarray_view_rejects_tensor_without_is_copied() {
+        let mut dlpack = versioned_2x3_dlpack(DlpackFlags::empty());
+
+        let error = array_view_from_dlpack_mut::<i32, _>(&mut dlpack).unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::Tensor {
+                source: crate::tensor::Error::NotCopied
+            }
+        ));
+    }
+
+    #[test]
+    fn mut_ndarray_view_rejects_legacy_tensor_as_never_copied() {
+        let mut dlpack = legacy_2x3_dlpack();
+
+        let error = array_view_from_dlpack_mut::<i32, _>(&mut dlpack).unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::Tensor {
+                source: crate::tensor::Error::NotCopied
+            }
+        ));
+    }
+
+    #[test]
+    fn try_into_mut_ndarray_view_requires_is_copied() {
+        let mut dlpack = versioned_2x3_dlpack(DlpackFlags::IS_COPIED);
+
+        let mut view = ArrayViewMutD::<i32>::try_from(&mut dlpack).unwrap();
+        view[[1, 2]] = 42;
+
+        assert_eq!(
+            dlpack.cpu_data_slice::<i32>().unwrap(),
+            &[1, 2, 3, 4, 5, 42]
+        );
     }
 
     #[test]

--- a/src/managed_tensor.rs
+++ b/src/managed_tensor.rs
@@ -22,6 +22,20 @@ bitflags! {
     }
 }
 
+impl DlpackFlags {
+    /// Whether setting `self` as the new flags, given the tensor's `current`
+    /// flags, would newly assert [`DlpackFlags::IS_COPIED`] — turn it on
+    /// when it wasn't already set.
+    ///
+    /// Turning it on is the risky direction: `ManagedBox::cpu_data_slice_mut`
+    /// and `array_view_from_dlpack_mut` trust it unconditionally to skip
+    /// aliasing checks. Leaving an already-set `IS_COPIED` on asserts
+    /// nothing new, so that case is not flagged.
+    pub(crate) fn newly_asserts_is_copied(self, current: DlpackFlags) -> bool {
+        self.contains(DlpackFlags::IS_COPIED) && !current.contains(DlpackFlags::IS_COPIED)
+    }
+}
+
 pub trait ManagedTensorBase {
     fn from_parts(
         tensor: DLTensor,
@@ -37,12 +51,20 @@ pub trait ManagedTensorBase {
         DlpackFlags::empty()
     }
 
-    /// Applies DLPack flags to this managed tensor.
+    /// Applies DLPack flags to this managed tensor verbatim, including
+    /// [`DlpackFlags::IS_COPIED`].
     ///
     /// Only `DLManagedTensorVersioned` carries a `flags` field; the legacy
     /// `DLManagedTensor` has none and inherits the default no-op, so callers
     /// can set flags generically over `M` without knowing which ABI it is.
-    fn set_flags(&mut self, _flags: crate::DlpackFlags) {}
+    ///
+    /// # Safety
+    ///
+    /// If `flags` includes `IS_COPIED`, the caller must ensure that no other
+    /// reference to the tensor's data exists: `ManagedBox::cpu_data_slice_mut`
+    /// and `array_view_from_dlpack_mut` trust that bit unconditionally and
+    /// skip aliasing checks accordingly.
+    unsafe fn set_flags_unchecked(&mut self, _flags: crate::DlpackFlags) {}
 
     /// Drops a raw managed tensor pointer through its DLPack deleter.
     ///
@@ -113,7 +135,7 @@ impl ManagedTensorBase for DLManagedTensorVersioned {
         self.deleter
     }
 
-    fn set_flags(&mut self, flags: crate::DlpackFlags) {
+    unsafe fn set_flags_unchecked(&mut self, flags: crate::DlpackFlags) {
         self.flags = flags;
     }
 

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -43,6 +43,14 @@ pub enum Error {
     #[snafu(display("tensor is read-only"))]
     ReadOnly,
 
+    #[snafu(display("tensor is not marked IS_COPIED, so exclusive ownership cannot be proven"))]
+    NotCopied,
+
+    #[snafu(display(
+        "cannot safely assert IS_COPIED; use the unchecked flag setter if exclusivity is verified"
+    ))]
+    CannotAssertIsCopied,
+
     #[snafu(display("tensor data pointer is null for a non-empty tensor"))]
     NullData,
 


### PR DESCRIPTION
sketch that closes #58

changes flags so it’s unsafe to toggle on IS_COPIED

LLM disclosure: Claude assisted, I didn’t read all the tests or doc comments.

If you want this, I’ll
1. think about the design of the flags. `.flags(READONLY).unwrap()` is always correct, so ideally the `.unwrap` shouldn’t be necessary.
2. give it a serious once-over until I verified every line