### PR TITLE
fix: gate bindgen layout tests on 64-bit pointer width

### DIFF
--- a/crates/dlpark-bindgen/src/main.rs
+++ b/crates/dlpark-bindgen/src/main.rs
@@ -24,7 +24,16 @@ fn main() -> Result<(), Whatever> {
         // otherwise treats their indented C/C++ contents as Rust doctests.
         .replace("\\\\code{.c}", "```c")
         .replace("\\\\code", "```text")
-        .replace("\\\\endcode", "```");
+        .replace("\\\\endcode", "```")
+        // bindgen emits struct size/offset layout tests using the host pointer
+        // width, so they fail to compile on 32-bit targets (e.g. wasm32) where
+        // pointer-containing structs are smaller. Gate every layout-test block
+        // on a 64-bit pointer width so the checks still run where they were
+        // generated but don't break 32-bit builds.
+        .replace(
+            "#[allow(clippy::unnecessary_operation, clippy::identity_op)]",
+            "#[cfg(target_pointer_width = \"64\")]\n#[allow(clippy::unnecessary_operation, clippy::identity_op)]",
+        );
 
     std::fs::write("src/ffi.rs", &post_processed).whatever_context("failed to write file")?;
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,6 +14,7 @@ pub struct DLPackVersion {
     #[doc = " DLPack minor version."]
     pub minor: u32,
 }
+#[cfg(target_pointer_width = "64")]
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of DLPackVersion"][::std::mem::size_of::<DLPackVersion>() - 8usize];
@@ -69,6 +70,7 @@ pub struct DLDevice {
     #[doc = " The device index.\n For vanilla CPU memory, pinned memory, or managed memory, this is set to 0."]
     pub device_id: i32,
 }
+#[cfg(target_pointer_width = "64")]
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of DLDevice"][::std::mem::size_of::<DLDevice>() - 8usize];
@@ -130,6 +132,7 @@ pub struct DLDataType {
     #[doc = " Number of lanes in the type, used for vector types."]
     pub lanes: u16,
 }
+#[cfg(target_pointer_width = "64")]
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of DLDataType"][::std::mem::size_of::<DLDataType>() - 4usize];
@@ -157,6 +160,7 @@ pub struct DLTensor {
     #[doc = " The offset in bytes to the beginning pointer to data"]
     pub byte_offset: u64,
 }
+#[cfg(target_pointer_width = "64")]
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of DLTensor"][::std::mem::size_of::<DLTensor>() - 48usize];
@@ -181,6 +185,7 @@ pub struct DLManagedTensor {
     #[doc = " Destructor - this should be called\n to destruct the manager_ctx  which backs the DLManagedTensor. It can be\n NULL if there is no way for the caller to provide a reasonable destructor.\n The destructor deletes the argument self as well."]
     pub deleter: ::std::option::Option<unsafe extern "C" fn(self_: *mut DLManagedTensor)>,
 }
+#[cfg(target_pointer_width = "64")]
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of DLManagedTensor"][::std::mem::size_of::<DLManagedTensor>() - 64usize];
@@ -207,6 +212,7 @@ pub struct DLManagedTensorVersioned {
     #[doc = " DLTensor which is being memory managed"]
     pub dl_tensor: DLTensor,
 }
+#[cfg(target_pointer_width = "64")]
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of DLManagedTensorVersioned"]
@@ -277,6 +283,7 @@ pub struct DLPackExchangeAPIHeader {
     #[doc = " Optional pointer to an older DLPackExchangeAPI in the chain.\n\n It must be NULL if the framework does not support older versions.\n If the current major version is larger than the one supported by the\n consumer, the consumer may walk this to find an earlier supported version.\n\n \\sa DLPackExchangeAPI"]
     pub prev_api: *mut DLPackExchangeAPIHeader,
 }
+#[cfg(target_pointer_width = "64")]
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of DLPackExchangeAPIHeader"][::std::mem::size_of::<DLPackExchangeAPIHeader>() - 16usize];
@@ -304,6 +311,7 @@ pub struct DLPackExchangeAPI {
     #[doc = " Producer function pointer for DLPackCurrentWorkStream\n        This function must be not NULL.\n \\sa DLPackCurrentWorkStream"]
     pub current_work_stream: DLPackCurrentWorkStream,
 }
+#[cfg(target_pointer_width = "64")]
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of DLPackExchangeAPI"][::std::mem::size_of::<DLPackExchangeAPI>() - 56usize];


### PR DESCRIPTION
Disclaimer: This was auto-generated by Claude, and I haven't looked at it yet.

---

## Problem

The bindgen-generated `src/ffi.rs` emits struct size/offset layout tests
using the **host** pointer width (64-bit). On 32-bit targets these hard-coded
sizes underflow at const-eval and the crate fails to compile. This breaks, for
example, `wasm32-unknown-emscripten` (the Pyodide wheel target):

```
error[E0080]: attempt to compute `12_usize - 16_usize`, which would overflow
   --> src/ffi.rs:282  ["Size of DLPackExchangeAPIHeader"][size_of::<…>() - 16usize];
error[E0080]: attempt to compute `32_usize - 56_usize`, which would overflow
   --> src/ffi.rs:309  ["Size of DLPackExchangeAPI"][size_of::<…>() - 56usize];
```

Every pointer-containing struct (`DLTensor`, `DLManagedTensor`,
`DLManagedTensorVersioned`, `DLPackExchangeAPIHeader`, `DLPackExchangeAPI`) is
affected, since function/data pointers are 4 bytes on wasm32 vs 8 on x86-64.
The struct *layouts* are correct on 32-bit (`#[repr(C)]` follows the target C
ABI) — only the generated size assertions, baked in from a 64-bit host, are
wrong.

## Fix

Gate every layout-test block on `#[cfg(target_pointer_width = "64")]`, so the
checks still run where they were generated (64-bit) but no longer break 32-bit
builds. The bindgen post-processing in `dlpark-bindgen` is updated to reproduce
the gate on regeneration, and `src/ffi.rs` is updated to match.

## Verification

```
cargo check -p dlpark --target wasm32-unknown-unknown   # was failing, now passes
cargo check -p dlpark                                   # 64-bit checks still run
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)